### PR TITLE
IDR build args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,10 @@ install:
   - python setup.py install
 
 before_script:
-  - mvn checkstyle:check
-  - flake8 -v .
+  - mvn -B checkstyle:check
+  - flake8 .
 
 script:
-  - mvn test
+  - mvn -B test
   - python test/all_tests.py
   - ./test/integration/run_local_features

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ COPY docker/centos7 /build
 
 RUN yum -y -q install epel-release && \
     yum -y -q install ansible
-# git is needed until openmicroscopy.omego is put on galaxy
-RUN yum -y -q install git
 RUN ansible-galaxy install -r /build/requirements.yml && \
     ansible-playbook /build/deps.yml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,8 @@ RUN printf 'PATH=$PATH:/build/OMERO.py/bin\n' > /etc/profile.d/omero.sh && \
 
 USER features
 ENV HOME /home/features
+# This is needed when running as a different user since some Python eggs
+# need to be unzipped
+ENV PYTHON_EGG_CACHE=/tmp/python-eggs
 
 ENTRYPOINT ["/usr/bin/pyfeatures"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,37 +3,31 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 COPY docker/centos7 /build
 
-COPY pom.xml /build/
-COPY setup.py /build
-COPY setup.cfg /build
-
-COPY src /build/src
-COPY pyfeatures /build/pyfeatures
+RUN yum -y -q install epel-release && \
+    yum -y -q install ansible
+# git is needed until openmicroscopy.omego is put on galaxy
+RUN yum -y -q install git
+RUN ansible-galaxy install -r /build/requirements.yml && \
+    ansible-playbook /build/deps.yml
 
 WORKDIR /build/
+
+COPY pyfeatures /build/pyfeatures
+COPY scripts /build/scripts
+COPY src /build/src
+COPY pom.xml setup.py setup.cfg /build/
+
 RUN bash build.sh
 
-# TODO: re-order later
-COPY scripts /build/scripts
 RUN bash -ic "python setup.py install"
 RUN yum -y install tkinter
 
 RUN useradd -m features
-RUN pip install omego \
- && omego download py
+ARG OMEGO_OPTS
+RUN /opt/omero/omego/bin/omego download py --sym OMERO.py $OMEGO_OPTS
 
-RUN find /build -type d -name "OMERO.server*" -maxdepth 1 -exec ln -s {} /build/OMERO.server \;
-RUN printf 'PATH=$PATH:/build/OMERO.server/bin\n' > /etc/profile.d/omero.sh \
- && printf 'PYTHONPATH=$PYTHONPATH:/build/OMERO.server/lib/python\n' >> /etc/profile.d/omero.sh
-
-COPY docker/centos7/deps.yml /build/
-RUN yum -y install epel-release \
- && yum -y install ansible
-RUN ansible-galaxy install openmicroscopy.ice \
- && ansible-galaxy install openmicroscopy.omero-python-deps \
- && ansible-playbook /build/deps.yml
-
-RUN printf '/build/OMERO.server/lib/python\n' > /usr/lib/python2.7/site-packages/omero.pth
+RUN printf 'PATH=$PATH:/build/OMERO.py/bin\n' > /etc/profile.d/omero.sh && \
+    printf '/build/OMERO.py/lib/python\n' > /usr/lib/python2.7/site-packages/omero.pth
 
 USER features
 ENV HOME /home/features

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ COPY scripts /build/scripts
 COPY src /build/src
 COPY pom.xml setup.py setup.cfg /build/
 
+ARG BIOFORMATS_GROUPID
+ARG BIOFORMATS_VERSION
 RUN bash build.sh
 
 RUN bash -ic "python setup.py install"

--- a/docker/centos7/build.sh
+++ b/docker/centos7/build.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 
-set -eux
+set -ex
+
+if [ -n "$BIOFORMATS_GROUPID" ]; then
+    sed -i -re \
+    "s%(<bio-formats.groupid>).+(</bio-formats.groupid>)%\1$BIOFORMATS_GROUPID\2%" \
+    pom.xml
+fi
+if [ -n "$BIOFORMATS_VERSION" ]; then
+    sed -i -re \
+    "s%(<bio-formats.version>).+(</bio-formats.version>)%\1$BIOFORMATS_VERSION\2%" \
+    pom.xml
+fi
 
 yum -y install epel-release
 yum -y install \

--- a/docker/centos7/deps.yml
+++ b/docker/centos7/deps.yml
@@ -1,5 +1,6 @@
 - hosts: localhost
   roles:
+  - role: openmicroscopy.omego
   - role: openmicroscopy.omero-python-deps
   - role: openmicroscopy.ice
   vars:

--- a/docker/centos7/requirements.yml
+++ b/docker/centos7/requirements.yml
@@ -1,10 +1,12 @@
 ---
 - src: openmicroscopy.ice
+  version: 2.0.0
 
 - src: openmicroscopy.omero-python-deps
+  version: 1.1.0
 
 - name: openmicroscopy.omero-common
-  src:  https://github.com/openmicroscopy/ansible-role-omero-common.git
+  src:  https://github.com/openmicroscopy/ansible-role-omero-common/archive/0.1.0.tar.gz
 
 - name: openmicroscopy.omego
-  src:  https://github.com/openmicroscopy/ansible-role-omego.git
+  src:  https://github.com/openmicroscopy/ansible-role-omego/archive/0.1.0.tar.gz

--- a/docker/centos7/requirements.yml
+++ b/docker/centos7/requirements.yml
@@ -1,0 +1,10 @@
+---
+- src: openmicroscopy.ice
+
+- src: openmicroscopy.omero-python-deps
+
+- name: openmicroscopy.omero-common
+  src:  https://github.com/openmicroscopy/ansible-role-omero-common.git
+
+- name: openmicroscopy.omego
+  src:  https://github.com/openmicroscopy/ansible-role-omego.git

--- a/pyfeatures/app/plot.py
+++ b/pyfeatures/app/plot.py
@@ -33,8 +33,6 @@ import shelve
 import warnings
 from contextlib import closing
 
-import matplotlib.pyplot as plt
-
 try:
     from pyavroc import AvroFileReader
 except ImportError:
@@ -97,6 +95,7 @@ def get_data(fn, axis, feature=None, x=None, y=None):
 
 
 def plot_data(data, axis, out_dir, logger):
+    import matplotlib.pyplot as plt
     other_axes = [_ for _ in AXES if _ != axis]
     for k1, v1 in data.iteritems():
         logger.debug("%r = %r", other_axes, k1)

--- a/pyfeatures/app/tiles.py
+++ b/pyfeatures/app/tiles.py
@@ -22,8 +22,6 @@ visual representation of the resulting coverage.
 """
 
 import numpy as np
-import matplotlib.pyplot as plt
-import matplotlib.patches as patches
 
 from pyfeatures.feature_calc import gen_tiles
 
@@ -48,6 +46,9 @@ def add_parser(subparsers):
 
 
 def run(logger, args, extra_argv=None):
+    import matplotlib.pyplot as plt
+    import matplotlib.patches as patches
+
     img_array = np.zeros((args.iH, args.iW), dtype="i1")
     fig = plt.figure()
     ax = fig.add_subplot(111, aspect='equal')

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ CLASSIFIERS = [
 
 
 def build_java():
-    sp.check_call(["mvn", "clean", "compile", "assembly:single"])
+    sp.check_call(["mvn", "-B", "clean", "compile", "assembly:single"])
 
 
 def write_schema_module():


### PR DESCRIPTION
Allows the IDR version of pyfeatures to be manually built by passing build-args, e.g. `docker build -t pydoop-features --build-arg OMEGO_OPTS="--release=0.3.5-rc1 --downloadurl=https://downloads.openmicroscopy.org/idr" --build-arg BIOFORMATS_GROUPID=idr --build-arg BIOFORMATS_VERSION=0.3.0 .`

Also delays the import of `matplotlib` since it's currently failing with the current `imagedata/pyfeatures`:
```
$ docker run -it --rm imagedata/pyfeatures --help
Traceback (most recent call last):
  File "/usr/bin/pyfeatures", line 33, in <module>
    main(sys.argv[1:])
  File "/usr/lib/python2.7/site-packages/pyfeatures/app/main.py", line 65, in main
    parser = make_parser()
  File "/usr/lib/python2.7/site-packages/pyfeatures/app/main.py", line 59, in make_parser
    mod = importlib.import_module("%s.%s" % (__package__, n))
  File "/usr/lib64/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/usr/lib/python2.7/site-packages/pyfeatures/app/plot.py", line 36, in <module>
    import matplotlib.pyplot as plt
  File "/usr/lib64/python2.7/site-packages/matplotlib/pyplot.py", line 26, in <module>
    from matplotlib.figure import Figure, figaspect
  File "/usr/lib64/python2.7/site-packages/matplotlib/figure.py", line 36, in <module>
    from matplotlib.axes import Axes, SubplotBase, subplot_class_factory
  File "/usr/lib64/python2.7/site-packages/matplotlib/axes/__init__.py", line 4, in <module>
    from ._subplots import *
  File "/usr/lib64/python2.7/site-packages/matplotlib/axes/_subplots.py", line 10, in <module>
    from matplotlib.axes._axes import Axes
  File "/usr/lib64/python2.7/site-packages/matplotlib/axes/_axes.py", line 15, in <module>
    from matplotlib import unpack_labeled_data
ImportError: cannot import name unpack_labeled_data
```