### PR TITLE
Add logback.xml to disable DEBUG logs in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <bio-formats.groupid>ome</bio-formats.groupid>
-    <bio-formats.version>5.3.0</bio-formats.version>
+    <bio-formats.version>5.3.1</bio-formats.version>
     <slf4j.version>1.7.7</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
     <hadoop.version>2.6.0</hadoop.version>

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%m%n</pattern>
+    </encoder>
+  </appender>
+  <root level="INFO">
+    <appender-ref ref="stdout"/>
+  </root>
+</configuration>


### PR DESCRIPTION
Travis currently fails due to DEBUG logs taking the logfile over 4MB. This commit attempts to disable DEBUG logging.

This appears to work when `mvn test` is run manually, but travis still fails.

@sbesson